### PR TITLE
fix: reduce agent tool-call hallucination probability

### DIFF
--- a/src/main/ai/OpenAICompatibleClient.ts
+++ b/src/main/ai/OpenAICompatibleClient.ts
@@ -64,7 +64,12 @@ async function readProviderError(response: Response): Promise<string> {
   return `Provider request failed (${response.status}): ${body || response.statusText}`
 }
 
-export function parseOpenAIStreamEvent(raw: string): string | null {
+export interface StreamDelta {
+  content?: string
+  reasoning?: string
+}
+
+export function parseOpenAIStreamEvent(raw: string): StreamDelta | null {
   const lines = raw
     .split('\n')
     .map((line) => line.trim())
@@ -73,16 +78,37 @@ export function parseOpenAIStreamEvent(raw: string): string | null {
   for (const line of lines) {
     const payload = line.slice(5).trim()
     if (!payload || payload === '[DONE]') return null
-    const parsed = JSON.parse(payload) as {
-      choices?: Array<{ delta?: { content?: string }; message?: { content?: string } }>
+    try {
+      const parsed = JSON.parse(payload) as {
+        choices?: Array<{
+          delta?: {
+            content?: string
+            reasoning_content?: string
+            reasoning?: string
+            thinking?: string
+          }
+          message?: { content?: string }
+        }>
+      }
+      const delta = parsed.choices?.[0]?.delta
+      if (!delta) continue
+      const content = delta.content ?? parsed.choices?.[0]?.message?.content
+      const reasoning = delta.reasoning_content ?? delta.reasoning ?? delta.thinking
+      if (typeof content === 'string' || typeof reasoning === 'string') {
+        const result: StreamDelta = {}
+        if (typeof content === 'string') result.content = content
+        if (typeof reasoning === 'string') result.reasoning = reasoning
+        return result
+      }
+    } catch {
+      // Incomplete or malformed JSON chunk — skip silently
+      continue
     }
-    const text = parsed.choices?.[0]?.delta?.content ?? parsed.choices?.[0]?.message?.content
-    if (typeof text === 'string') return text
   }
   return null
 }
 
-export function parseAnthropicStreamEvent(raw: string): string | null {
+export function parseAnthropicStreamEvent(raw: string): StreamDelta | null {
   const lines = raw
     .split('\n')
     .map((line) => line.trim())
@@ -90,21 +116,31 @@ export function parseAnthropicStreamEvent(raw: string): string | null {
 
   for (const line of lines) {
     const payload = line.slice(5).trim()
-    if (!payload) return null
+    if (!payload) continue
 
-    const parsed = JSON.parse(payload) as {
-      type?: string
-      delta?: { type?: string; text?: string }
-    }
+    try {
+      const parsed = JSON.parse(payload) as {
+        type?: string
+        delta?: { type?: string; text?: string; thinking?: string }
+      }
 
-    if (parsed.type === 'content_block_delta' && parsed.delta?.type === 'text_delta' && parsed.delta.text) {
-      return parsed.delta.text
+      if (parsed.type === 'content_block_delta' && parsed.delta) {
+        if (parsed.delta.type === 'text_delta' && parsed.delta.text) {
+          return { content: parsed.delta.text }
+        }
+        if (parsed.delta.type === 'thinking_delta' && parsed.delta.thinking) {
+          return { reasoning: parsed.delta.thinking }
+        }
+      }
+    } catch {
+      // Incomplete or malformed JSON chunk — skip silently
+      continue
     }
   }
   return null
 }
 
-function parseProviderStreamEvent(apiType: ProviderApiType, raw: string): string | null {
+function parseProviderStreamEvent(apiType: ProviderApiType, raw: string): StreamDelta | null {
   return apiType === 'anthropic' ? parseAnthropicStreamEvent(raw) : parseOpenAIStreamEvent(raw)
 }
 
@@ -139,14 +175,13 @@ function buildAnthropicContent(message: AiMessageInput): unknown {
   return parts
 }
 
-export async function streamChatCompletion(
-  provider: ProviderSettings,
-  prompt: string,
-  systemPrompt: string,
-  signal: AbortSignal,
-  onDelta: (delta: string) => void
-): Promise<void> {
-  return streamChatMessages(provider, [{ role: 'user', text: prompt }], systemPrompt, signal, onDelta)
+// SSE events are separated by a blank line; some providers emit CRLF line endings.
+const SSE_EVENT_SEPARATOR = /\r?\n\r?\n/
+
+// Anthropic requires max_tokens; give reasoning modes extra room so long
+// answers are not silently truncated.
+function defaultMaxTokens(reasoning: ReasoningMode): number {
+  return reasoning === 'high' ? 8192 : reasoning === 'off' ? 4096 : 6144
 }
 
 const anthropicThinkingBudget: Record<Extract<ReasoningMode, 'low' | 'medium' | 'high'>, number> = {
@@ -173,11 +208,170 @@ function applyReasoning(body: Record<string, unknown>, apiType: ProviderApiType,
   if (apiType === 'anthropic') {
     const budget = anthropicThinkingBudget[reasoning]
     body.thinking = { type: 'enabled', budget_tokens: budget }
-    body.max_tokens = Math.max(typeof body.max_tokens === 'number' ? body.max_tokens : 0, budget + 1024)
+    // Keep enough room for the visible answer on top of the thinking budget.
+    body.max_tokens = Math.max(typeof body.max_tokens === 'number' ? body.max_tokens : 0, budget + 4096)
     return
   }
 
   body.reasoning_effort = reasoning
+}
+
+export interface ToolDefinition {
+  name: string
+  description: string
+  parameters: Record<string, unknown>
+}
+
+interface AccumulatedToolCall {
+  id: string
+  name: string
+  arguments: string
+}
+
+interface ToolCallStreamOptions extends ProviderRequestOptions {
+  tools?: ToolDefinition[]
+  onToolCall?: (name: string, args: Record<string, unknown>) => Promise<string>
+  onStatus?: (text: string, toolName?: string) => void
+  /** Max tool-calling rounds before giving up. Defaults to 5 (web-search style). */
+  maxToolRounds?: number
+  /** Wall-clock budget for model streaming across the tool loop. Time spent
+   * inside onToolCall (tool execution and user-approval waits) is excluded,
+   * so a pending approval can never time the stream out. */
+  toolLoopTimeoutMs?: number
+  /** Streamed to the user as content when the loop stops because
+   * maxToolRounds was exhausted while the model still wanted more calls. */
+  roundLimitNotice?: string
+  /** Drained between tool rounds — returns user notes queued while the loop
+   * was running so mid-task guidance reaches the model at the next gap. */
+  drainInjected?: () => string[]
+  /** Override temperature for the tool-calling loop (agent mode uses a low
+   * value to reduce hallucinated tool calls). */
+  agentTemperature?: number
+}
+
+// In-loop context control, mirroring the renderer's "keep the last ~5 rounds
+// verbatim" policy: every result is capped, and results older than the recent
+// window get stubbed out (the model can always re-run the tool if needed).
+/** Hard cap on a single tool result sent to the model (chars). */
+const TOOL_RESULT_MAX_CHARS = 12_000
+/** Rounds whose tool results are kept verbatim; older ones become stubs.
+ * Too small forgets files the model just read, forcing re-reads that burn
+ * extra rounds — the re-read loop costs more than the retained context. */
+const TOOL_KEEP_RECENT_ROUNDS = 10
+/** Length a stubbed-out old result is trimmed down to. */
+const TOOL_STUB_CHARS = 300
+
+/** Cap an oversized result keeping head + tail — command failures usually
+ * sit at the end of the output, file reads at the start. */
+function capToolResult(content: string): string {
+  if (content.length <= TOOL_RESULT_MAX_CHARS) return content
+  const head = content.slice(0, Math.floor(TOOL_RESULT_MAX_CHARS * 0.7))
+  const tail = content.slice(-Math.floor(TOOL_RESULT_MAX_CHARS * 0.25))
+  return `${head}\n\n[... ${content.length - head.length - tail.length} chars truncated ...]\n\n${tail}`
+}
+
+/** Replace an aged-out result with a short stub of its beginning. */
+function stubToolResult(content: string): string {
+  if (content.length <= TOOL_STUB_CHARS) return content
+  return `${content.slice(0, TOOL_STUB_CHARS)}\n[... earlier tool output trimmed to save context — call the tool again if you need it ...]`
+}
+
+/** Parse OpenAI streaming event for tool-call fragments. */
+function extractOpenAIToolCalls(
+  raw: string,
+  map: Map<number, AccumulatedToolCall>
+): void {
+  const lines = raw.split('\n').map((l) => l.trim()).filter((l) => l.startsWith('data:'))
+  for (const line of lines) {
+    const payload = line.slice(5).trim()
+    if (!payload || payload === '[DONE]') continue
+    try {
+      const parsed = JSON.parse(payload) as {
+        choices?: Array<{
+          delta?: {
+            tool_calls?: Array<{
+              index?: number
+              id?: string
+              function?: { name?: string; arguments?: string }
+            }>
+          }
+        }>
+      }
+      const toolCalls = parsed.choices?.[0]?.delta?.tool_calls
+      if (!Array.isArray(toolCalls)) continue
+      for (const tc of toolCalls) {
+        const idx = tc.index ?? 0
+        const existing = map.get(idx) ?? { id: '', name: '', arguments: '' }
+        if (tc.id) existing.id = tc.id
+        if (tc.function?.name) existing.name = tc.function.name
+        if (tc.function?.arguments) existing.arguments += tc.function.arguments
+        map.set(idx, existing)
+      }
+    } catch {
+      // skip
+    }
+  }
+}
+
+/** One streamed Anthropic content block (text / thinking / tool_use). */
+export interface AnthropicStreamBlock {
+  type: 'text' | 'thinking' | 'tool_use'
+  text: string
+  thinking: string
+  signature: string
+  id: string
+  name: string
+  json: string
+}
+
+/** Parse Anthropic streaming events and accumulate every content block by index. */
+export function extractAnthropicBlocks(raw: string, map: Map<number, AnthropicStreamBlock>): void {
+  const lines = raw.split('\n').map((l) => l.trim()).filter((l) => l.startsWith('data:'))
+  for (const line of lines) {
+    const payload = line.slice(5).trim()
+    if (!payload) continue
+    try {
+      const parsed = JSON.parse(payload) as {
+        type?: string
+        index?: number
+        content_block?: { type?: string; id?: string; name?: string; text?: string }
+        delta?: { type?: string; text?: string; thinking?: string; signature?: string; partial_json?: string }
+      }
+      const idx = parsed.index ?? 0
+      if (parsed.type === 'content_block_start' && parsed.content_block?.type) {
+        const blockType = parsed.content_block.type
+        if (blockType === 'text' || blockType === 'thinking' || blockType === 'tool_use') {
+          map.set(idx, {
+            type: blockType,
+            text: parsed.content_block.text ?? '',
+            thinking: '',
+            signature: '',
+            id: parsed.content_block.id ?? '',
+            name: parsed.content_block.name ?? '',
+            json: ''
+          })
+        }
+      }
+      if (parsed.type === 'content_block_delta' && parsed.delta) {
+        const block = map.get(idx)
+        if (!block) continue
+        if (parsed.delta.type === 'text_delta' && parsed.delta.text) block.text += parsed.delta.text
+        if (parsed.delta.type === 'thinking_delta' && parsed.delta.thinking) block.thinking += parsed.delta.thinking
+        if (parsed.delta.type === 'signature_delta' && parsed.delta.signature) block.signature += parsed.delta.signature
+        // Anthropic streams tool arguments as input_json_delta fragments
+        if (parsed.delta.type === 'input_json_delta' && parsed.delta.partial_json) block.json += parsed.delta.partial_json
+      }
+    } catch {
+      // skip
+    }
+  }
+}
+
+function buildToolsBody(apiType: ProviderApiType, tools: ToolDefinition[]): unknown[] {
+  if (apiType === 'anthropic') {
+    return tools.map((t) => ({ name: t.name, description: t.description, input_schema: t.parameters }))
+  }
+  return tools.map((t) => ({ type: 'function', function: { name: t.name, description: t.description, parameters: t.parameters } }))
 }
 
 export async function streamChatMessages(
@@ -185,76 +379,314 @@ export async function streamChatMessages(
   messages: AiMessageInput[],
   systemPrompt: string,
   signal: AbortSignal,
-  onDelta: (delta: string) => void,
+  onDelta: (delta: StreamDelta) => void,
   reasoning: ReasoningMode = 'on',
-  options: ProviderRequestOptions = {}
+  options: ToolCallStreamOptions = {}
 ): Promise<void> {
   assertProviderReady(provider)
+  const { tools, onToolCall, onStatus } = options
+  const useToolCalling = !!(tools?.length && onToolCall)
 
-  const body: Record<string, unknown> =
-    provider.apiType === 'anthropic'
-      ? {
-          model: provider.model,
-          temperature: provider.temperature,
-          max_tokens: 1024,
-          stream: true,
-          system: systemPrompt,
-          messages: messages.map((message) => ({
-            role: message.role,
-            content: buildAnthropicContent(message)
-          }))
-        }
-      : {
-          model: provider.model,
-          temperature: provider.temperature,
-          stream: true,
-          messages: [
-            { role: 'system', content: systemPrompt },
-            ...messages.map((message) => ({
+  // ---- Simple flow (no tools) — existing behaviour ----
+  if (!useToolCalling) {
+    const body: Record<string, unknown> =
+      provider.apiType === 'anthropic'
+        ? {
+            model: provider.model,
+            temperature: provider.temperature,
+            max_tokens: defaultMaxTokens(reasoning),
+            stream: true,
+            system: systemPrompt,
+            messages: messages.map((message) => ({
               role: message.role,
-              content: buildOpenAIContent(message)
+              content: buildAnthropicContent(message)
             }))
-          ]
-        }
-  applyReasoning(body, provider.apiType, reasoning)
+          }
+        : {
+            model: provider.model,
+            temperature: provider.temperature,
+            stream: true,
+            messages: [
+              { role: 'system', content: systemPrompt },
+              ...messages.map((message) => ({
+                role: message.role,
+                content: buildOpenAIContent(message)
+              }))
+            ]
+          }
+    applyReasoning(body, provider.apiType, reasoning)
 
-  const response = await fetchProvider(
-    buildProviderUrl(provider, provider.apiType === 'anthropic' ? 'messages' : 'chat/completions'),
-    {
-      method: 'POST',
-      signal,
-      headers: buildProviderHeaders(provider),
-      body: JSON.stringify(body)
-    },
-    options
-  )
+    const response = await fetchProvider(
+      buildProviderUrl(provider, provider.apiType === 'anthropic' ? 'messages' : 'chat/completions'),
+      { method: 'POST', signal, headers: buildProviderHeaders(provider), body: JSON.stringify(body) },
+      options
+    )
+    if (!response.ok) throw new Error(await readProviderError(response))
+    if (!response.body) throw new Error('Provider returned an empty response body.')
 
-  if (!response.ok) {
-    throw new Error(await readProviderError(response))
-  }
-  if (!response.body) throw new Error('Provider returned an empty response body.')
-
-  const reader = response.body.getReader()
-  const decoder = new TextDecoder()
-  let buffer = ''
-
-  while (true) {
-    const { value, done } = await reader.read()
-    if (done) break
-
-    buffer += decoder.decode(value, { stream: true })
-    const events = buffer.split('\n\n')
-    buffer = events.pop() ?? ''
-
-    for (const event of events) {
-      const delta = parseProviderStreamEvent(provider.apiType, event)
+    const reader = response.body.getReader()
+    const decoder = new TextDecoder()
+    let buffer = ''
+    while (true) {
+      const { value, done } = await reader.read()
+      if (done) break
+      buffer += decoder.decode(value, { stream: true })
+      const events = buffer.split(SSE_EVENT_SEPARATOR)
+      buffer = events.pop() ?? ''
+      for (const event of events) {
+        const delta = parseProviderStreamEvent(provider.apiType, event)
+        if (delta) onDelta(delta)
+      }
+    }
+    if (buffer.trim()) {
+      const delta = parseProviderStreamEvent(provider.apiType, buffer)
       if (delta) onDelta(delta)
     }
+    return
   }
 
-  if (buffer.trim()) {
-    const delta = parseProviderStreamEvent(provider.apiType, buffer)
-    if (delta) onDelta(delta)
+  // ---- Tool-calling flow ----
+  const apiType = provider.apiType
+  const maxRounds = options.maxToolRounds ?? 5
+  const toolLoopTimeoutMs = options.toolLoopTimeoutMs ?? 60_000
+  const loopStart = Date.now()
+  // Time spent inside onToolCall — excluded from the loop budget so slow
+  // commands and approval pauses do not abort the conversation.
+  let toolTimeMs = 0
+  // Tool-result messages indexed by the round they were produced in, so
+  // rounds that fall out of the recent window can be shrunk in place —
+  // long agent sessions otherwise accumulate every file read and command
+  // output and eventually overflow the model context.
+  const toolResultRefs: Array<{ round: number; shrink: () => void; shrunk?: boolean }> = []
+
+  // Build initial API messages array
+  let apiMessages: unknown[]
+  if (apiType === 'anthropic') {
+    apiMessages = messages.map((m) => ({ role: m.role, content: buildAnthropicContent(m) }))
+  } else {
+    apiMessages = [
+      { role: 'system', content: systemPrompt },
+      ...messages.map((m) => ({ role: m.role, content: buildOpenAIContent(m) }))
+    ]
+  }
+
+  // True when the loop ends with the model still asking for tool calls.
+  let roundLimitHit = true
+  for (let round = 0; round < maxRounds; round++) {
+    if (Date.now() - loopStart - toolTimeMs > toolLoopTimeoutMs) {
+      throw new Error(`Tool-calling loop timed out (${Math.round(toolLoopTimeoutMs / 1000)}s of model streaming)`)
+    }
+    // Age out tool results older than the recent-rounds window (mirrors the
+    // renderer's "keep the last ~5 rounds verbatim" compression policy).
+    for (const ref of toolResultRefs) {
+      if (!ref.shrunk && ref.round <= round - TOOL_KEEP_RECENT_ROUNDS) {
+        ref.shrink()
+        ref.shrunk = true
+      }
+    }
+    // Deliver user notes queued while the previous round was streaming or
+    // executing tools — the gap between rounds is the only safe place to
+    // add a user message without breaking the tool-call protocol.
+    for (const note of options.drainInjected?.() ?? []) {
+      if (apiType === 'anthropic') {
+        // Anthropic requires alternating roles; tool results already sit in a
+        // trailing user message, so append a text block to it when present
+        // (tool_result blocks must come first, text after them is valid).
+        const last = apiMessages[apiMessages.length - 1] as { role?: string; content?: unknown }
+        if (last?.role === 'user' && Array.isArray(last.content)) {
+          last.content.push({ type: 'text', text: note })
+        } else {
+          apiMessages.push({ role: 'user', content: [{ type: 'text', text: note }] })
+        }
+      } else {
+        apiMessages.push({ role: 'user', content: note })
+      }
+    }
+    // Dynamically set max_tokens: reasoning modes need more room
+    const dynMaxTokens = defaultMaxTokens(reasoning)
+    const loopTemp = options.agentTemperature ?? provider.temperature
+    const body: Record<string, unknown> =
+      apiType === 'anthropic'
+        ? {
+            model: provider.model,
+            temperature: loopTemp,
+            max_tokens: dynMaxTokens,
+            stream: true,
+            system: systemPrompt,
+            messages: apiMessages,
+            tools: buildToolsBody(apiType, tools!)
+          }
+        : {
+            model: provider.model,
+            temperature: loopTemp,
+            stream: true,
+            messages: apiMessages,
+            tools: buildToolsBody(apiType, tools!)
+          }
+    applyReasoning(body, apiType, reasoning)
+
+    const response = await fetchProvider(
+      buildProviderUrl(provider, apiType === 'anthropic' ? 'messages' : 'chat/completions'),
+      { method: 'POST', signal, headers: buildProviderHeaders(provider), body: JSON.stringify(body) },
+      options
+    )
+    if (!response.ok) throw new Error(await readProviderError(response))
+    if (!response.body) throw new Error('Provider returned an empty response body.')
+
+    // Stream, forward deltas, and accumulate this round's content for the
+    // assistant message we may need to send back with the tool results.
+    const reader = response.body.getReader()
+    const decoder = new TextDecoder()
+    let buffer = ''
+    const toolCallMap = new Map<number, AccumulatedToolCall>()
+    const anthropicBlocks = new Map<number, AnthropicStreamBlock>()
+    let roundText = ''
+
+    const handleEvent = (event: string): void => {
+      const delta = parseProviderStreamEvent(apiType, event)
+      if (delta) {
+        if (delta.content) roundText += delta.content
+        onDelta(delta)
+      }
+      if (apiType === 'anthropic') {
+        extractAnthropicBlocks(event, anthropicBlocks)
+      } else {
+        extractOpenAIToolCalls(event, toolCallMap)
+      }
+    }
+
+    while (true) {
+      const { value, done } = await reader.read()
+      if (done) break
+      buffer += decoder.decode(value, { stream: true })
+      const events = buffer.split(SSE_EVENT_SEPARATOR)
+      buffer = events.pop() ?? ''
+      for (const event of events) handleEvent(event)
+    }
+    if (buffer.trim()) handleEvent(buffer)
+
+    const toolCalls: AccumulatedToolCall[] =
+      apiType === 'anthropic'
+        ? Array.from(anthropicBlocks.values())
+            .filter((b) => b.type === 'tool_use' && b.id && b.name)
+            .map((b) => ({ id: b.id, name: b.name, arguments: b.json }))
+        : Array.from(toolCallMap.values()).filter((tc) => tc.id && tc.name)
+    if (toolCalls.length === 0) {
+      // Hallucination guard: if the model wrote text that looks like it
+      // performed tool actions (file edits, command runs, etc.) without
+      // actually issuing tool calls, warn the user. This catches the
+      // "narrating work as done" anti-pattern. Only fire when tools are
+      // available AND the model is in the middle of a multi-round task
+      // (round > 0), since round 0 may legitimately be a plan.
+      if (round > 0 && roundText.length > 0) {
+        const hallucinationPatterns = [
+          /(?:已[经成]?|successfully)\s*(?:创建|修改|编辑|写入|删除|执行|运行|部署|create|edit|modif|writ|delet|execut|ran|deploy|built|install)/i,
+          /(?:文件|file)\s*(?:已|has been)\s*(?:保存|更新|创建|saved|updated|created)/i,
+          /```(?:diff|patch)\n[+-]/,
+          /(?:Step|步骤)\s*\d+[.：:]\s*(?:✓|✅|Done|完成|已完成)/i,
+        ]
+        const looksHallucinated = hallucinationPatterns.some((p) => p.test(roundText))
+        if (looksHallucinated) {
+          const warn =
+            options.roundLimitNotice?.includes('继续')
+              ? '\n\n⚠️ 上述内容可能是计划描述而非实际执行结果。如需执行，请回复"执行"，我会用工具实际完成操作。'
+              : '\n\n⚠️ The above may describe planned actions rather than actual results. Reply "go ahead" and I\'ll execute them with real tool calls.'
+          onDelta({ content: warn })
+        }
+      }
+      roundLimitHit = false
+      break // no tool calls — we're done
+    }
+
+    // Echo back the full assistant turn (thinking/text/tool_use) so the API
+    // accepts the follow-up request — Anthropic rejects turns that drop
+    // thinking blocks when extended thinking is enabled.
+    if (apiType === 'anthropic') {
+      const contentBlocks: unknown[] = []
+      for (const [, block] of [...anthropicBlocks.entries()].sort((a, b) => a[0] - b[0])) {
+        if (block.type === 'thinking' && block.thinking) {
+          contentBlocks.push({ type: 'thinking', thinking: block.thinking, signature: block.signature })
+        } else if (block.type === 'text' && block.text) {
+          contentBlocks.push({ type: 'text', text: block.text })
+        } else if (block.type === 'tool_use' && block.id && block.name) {
+          let input: Record<string, unknown> = {}
+          try {
+            input = JSON.parse(block.json || '{}')
+          } catch {
+            // leave empty input
+          }
+          contentBlocks.push({ type: 'tool_use', id: block.id, name: block.name, input })
+        }
+      }
+      apiMessages.push({ role: 'assistant', content: contentBlocks })
+    } else {
+      apiMessages.push({
+        role: 'assistant',
+        content: roundText || null,
+        tool_calls: toolCalls.map((tc) => ({
+          id: tc.id,
+          type: 'function',
+          function: { name: tc.name, arguments: tc.arguments }
+        }))
+      })
+    }
+
+    // Execute each tool call and collect the results
+    const toolResults: Array<{ id: string; content: string }> = []
+    const execStart = Date.now()
+    for (const tc of toolCalls) {
+      let args: Record<string, unknown> = {}
+      try {
+        args = JSON.parse(tc.arguments || '{}')
+      } catch (e) {
+        console.warn('[tool-call] failed to parse arguments for', tc.name, ':', tc.arguments, e)
+      }
+
+      try {
+        onStatus?.(typeof args.query === 'string' ? args.query : tc.name, tc.name)
+        const result = await onToolCall!(tc.name, args)
+        toolResults.push({ id: tc.id, content: result })
+      } catch (error) {
+        if (signal.aborted) throw error
+        const msg = error instanceof Error ? error.message : String(error)
+        onStatus?.(`⚠️ ${msg}`, tc.name)
+        // Still send a tool result so the conversation can continue
+        toolResults.push({ id: tc.id, content: `[Search failed: ${msg}]` })
+      }
+    }
+    toolTimeMs += Date.now() - execStart
+
+    if (apiType === 'anthropic') {
+      const resultBlocks = toolResults.map((r) => ({
+        type: 'tool_result',
+        tool_use_id: r.id,
+        content: capToolResult(r.content)
+      }))
+      apiMessages.push({ role: 'user', content: resultBlocks })
+      toolResultRefs.push({
+        round,
+        shrink: () => {
+          for (const block of resultBlocks) block.content = stubToolResult(block.content)
+        }
+      })
+    } else {
+      for (const r of toolResults) {
+        const msg = { role: 'tool', tool_call_id: r.id, content: capToolResult(r.content) }
+        apiMessages.push(msg)
+        toolResultRefs.push({
+          round,
+          shrink: () => {
+            msg.content = stubToolResult(msg.content)
+          }
+        })
+      }
+    }
+    // Loop again — the model will continue with the tool results
+  }
+  // Surface round exhaustion instead of ending the reply silently — the
+  // user can simply ask to continue in the next turn.
+  if (roundLimitHit && options.roundLimitNotice) {
+    onDelta({ content: `\n\n${options.roundLimitNotice}` })
   }
 }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,34 +1,51 @@
-import { app, BrowserWindow, Menu, Tray, globalShortcut, ipcMain, nativeImage, net, shell } from 'electron'
-import { electronApp, optimizer } from '@electron-toolkit/utils'
-import { existsSync } from 'node:fs'
-import { fileURLToPath } from 'node:url'
-import { dirname, join } from 'node:path'
+import { app, BrowserWindow, Menu, Tray, dialog, globalShortcut, ipcMain, nativeImage, net, shell } from 'electron'
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
+import { writeFile } from 'node:fs/promises'
+import { randomUUID } from 'node:crypto'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
 import { buildAssistantSystemPrompt, resolveProvider } from '@shared/actions'
 import { IPC } from '@shared/ipc'
 import { APP_ICON_DATA_URL, APP_TRAY_DATA_URL } from '@shared/brand'
-import type { AiStreamRequest, SettingsPatch } from '@shared/types'
+import type { AgentToolEvent, AiStreamRequest, SettingsPatch } from '@shared/types'
 import { listModels, streamChatMessages, testModel, type ProviderFetch } from './ai/OpenAICompatibleClient'
-import { decideSearch, formatSearchContext, searchExa } from './ai/WebSearch'
+import { formatSearchContext, searchWithFallback, webSearchTool } from './ai/WebSearch'
+import { agentToolDefinitions, assessCommandRisk, executeAgentTool, requiresApproval, restoreSnapshot, snapshotForMutation, summarizeToolCall } from './agent/AgentTools'
+import { deleteSnapshot, loadSnapshot, saveSnapshot } from './agent/SnapshotStore'
+import { cancelApprovalsForRequest, resolveApproval, waitForApproval } from './agent/AgentSession'
+import { buildMemoryPrompt, ensureGlobalMemoryFile, getGlobalMemoryPath } from './memory'
+import { buildSkillsPrompt, getSkillsDir, readSkillMeta, scanSkills } from './skills'
+import { mcpManager } from './mcp/McpManager'
+import { applyProxy, testProxy } from './proxy'
+import { isMcpToolName } from './mcp/mcpUtil'
 import { ScreenshotService } from './ScreenshotService'
 import { SelectionService } from './SelectionService'
 import { SpeechService } from './SpeechService'
 import { getSettings, onSettingsChanged, updateSettings } from './settingsStore'
 import { isSupportedPlatform, isWin } from './platform'
 
-const __dirname = dirname(fileURLToPath(import.meta.url))
-const preloadPath = join(__dirname, '../preload/index.mjs')
+const preloadPath = join(__dirname, '../preload/index.cjs')
 const rendererDir = join(__dirname, '../renderer')
 
 if (isWin) app.commandLine.appendSwitch('wm-window-animations-disabled')
+// Cap the V8 old space to keep memory bounded, but leave enough headroom for
+// large screenshot data URLs (a 4K capture is tens of MB as a base64 string).
+app.commandLine.appendSwitch('js-flags', '--max-old-space-size=512')
 
 let settingsWindow: BrowserWindow | null = null
 let chatWindow: BrowserWindow | null = null
 let tray: Tray | null = null
 let isQuitting = false
+
+// Pre-images of agent write/edit calls are persisted to disk (see
+// SnapshotStore) so revert from the tool card survives an app restart.
 const CHAT_SHADOW_PADDING = 18
-const CHAT_DEFAULT_WIDTH = 440
-const CHAT_DEFAULT_HEIGHT = 580
+const CHAT_DEFAULT_WIDTH = 520
+const CHAT_DEFAULT_HEIGHT = 640
 const abortControllers = new Map<string, AbortController>()
+// User notes queued mid-request, delivered into the tool loop between rounds
+// (see drainInjected). Entry exists only while its request is streaming.
+const injectionQueues = new Map<string, string[]>()
 const providerFetch: ProviderFetch = (url, init) => net.fetch(url, init)
 
 function createNativeImageFromFile(paths: string[], fallbackDataUrl: string): Electron.NativeImage {
@@ -40,20 +57,44 @@ function createNativeImageFromFile(paths: string[], fallbackDataUrl: string): El
   return nativeImage.createFromDataURL(fallbackDataUrl)
 }
 
-const appIcon = createNativeImageFromFile(
-  app.isPackaged
-    ? [join(process.resourcesPath, 'build', 'icon.png')]
-    : [join(__dirname, '../../build/icon.png'), join(process.cwd(), 'build', 'icon.png')],
-  APP_ICON_DATA_URL
+// Packaged: build/icon.png lives inside app.asar (readable via Electron's
+// patched fs); some builds also copy it next to resources. The data-URL
+// fallbacks are SVG, which nativeImage cannot decode — never rely on them
+// for the tray or it renders as an invisible blank icon.
+const packagedIconPaths = [
+  join(app.getAppPath(), 'build', 'icon.png'),
+  join(process.resourcesPath, 'build', 'icon.png')
+]
+const devIconPaths = [join(__dirname, '../../build/icon.png'), join(process.cwd(), 'build', 'icon.png')]
+
+const appIcon = createNativeImageFromFile(app.isPackaged ? packagedIconPaths : devIconPaths, APP_ICON_DATA_URL)
+const trayIcon = createNativeImageFromFile(app.isPackaged ? packagedIconPaths : devIconPaths, APP_TRAY_DATA_URL)
+const selectionService = new SelectionService(getSettings, updateSettings, preloadPath, rendererDir, appIcon)
+const screenshotService = new ScreenshotService(
+  getSettings,
+  preloadPath,
+  rendererDir,
+  appIcon,
+  (imageDataUrl) => {
+    // Reuse the action window for vision instead of spawning a dedicated preview process.
+    const isZh = getSettings().language === 'zh-CN'
+    selectionService.processAction({
+      action: {
+        // Unique id so reusing the action window remounts for each capture.
+        id: `screenshot-explain-${Date.now()}`,
+        name: isZh ? 'AI 识图' : 'AI Vision',
+        enabled: true,
+        icon: 'sparkles',
+        type: 'prompt',
+        promptTemplate: isZh
+          ? '直接用简洁易懂的话解释这张图片。抓住重点，不要废话，不要逐一描述画面元素，也不要堆砌冗长段落；只有在真正有帮助时再补一句简短总结。'
+          : 'Explain this image directly in plain, easy-to-understand language. Be concise, stay focused on the key point, avoid listing every visual element, and skip filler. Add a brief summary only when it is genuinely helpful.'
+      },
+      selectedText: '',
+      images: [imageDataUrl]
+    })
+  }
 )
-const trayIcon = createNativeImageFromFile(
-  app.isPackaged
-    ? [join(process.resourcesPath, 'build', 'icon.png')]
-    : [join(__dirname, '../../build/icon.png'), join(process.cwd(), 'build', 'icon.png')],
-  APP_TRAY_DATA_URL
-)
-const selectionService = new SelectionService(getSettings, preloadPath, rendererDir, appIcon)
-const screenshotService = new ScreenshotService(getSettings, preloadPath, rendererDir, appIcon)
 const speechService = new SpeechService()
 
 function getTrayIcon(): Electron.NativeImage {
@@ -80,7 +121,18 @@ function mainText(key: 'enable' | 'disable' | 'settings' | 'stopSpeech' | 'quit'
 
 function loadRenderer(win: BrowserWindow, page: string): void {
   if (process.env.ELECTRON_RENDERER_URL) {
-    void win.loadURL(`${process.env.ELECTRON_RENDERER_URL}/${page}`)
+    const url = `${process.env.ELECTRON_RENDERER_URL}/${page}`
+    // Dev-only: the vite server may still be starting (dependency
+    // re-optimization) when the first window loads — retry until it is up.
+    let attempts = 0
+    const tryLoad = (): void => {
+      win.loadURL(url).catch(() => {
+        if (win.isDestroyed() || attempts >= 20) return
+        attempts += 1
+        setTimeout(tryLoad, 500)
+      })
+    }
+    tryLoad()
   } else {
     void win.loadFile(join(rendererDir, page))
   }
@@ -106,7 +158,8 @@ function createSettingsWindow(): BrowserWindow {
       preload: preloadPath,
       contextIsolation: true,
       nodeIntegration: false,
-      sandbox: false
+      sandbox: true,
+      backgroundThrottling: true
     }
   })
   settingsWindow.on('close', (event) => {
@@ -130,9 +183,13 @@ function openChatWindow(): void {
     chatWindow.focus()
     return
   }
+  const settings = getSettings()
+  // Chat window always remembers its size (independent of rememberWindowSize toggle)
+  const chatWidth = settings.chatWindowWidth ?? CHAT_DEFAULT_WIDTH
+  const chatHeight = settings.chatWindowHeight ?? CHAT_DEFAULT_HEIGHT
   chatWindow = new BrowserWindow({
-    width: CHAT_DEFAULT_WIDTH + CHAT_SHADOW_PADDING * 2,
-    height: CHAT_DEFAULT_HEIGHT + CHAT_SHADOW_PADDING * 2,
+    width: chatWidth + CHAT_SHADOW_PADDING * 2,
+    height: chatHeight + CHAT_SHADOW_PADDING * 2,
     minWidth: 360 + CHAT_SHADOW_PADDING * 2,
     minHeight: 360 + CHAT_SHADOW_PADDING * 2,
     icon: appIcon,
@@ -142,24 +199,50 @@ function openChatWindow(): void {
     frame: false,
     transparent: true,
     hasShadow: false,
+    paintWhenInitiallyHidden: true,
     titleBarStyle: 'hidden',
     trafficLightPosition: { x: CHAT_SHADOW_PADDING + 12, y: CHAT_SHADOW_PADDING + 10 },
     webPreferences: {
       preload: preloadPath,
       contextIsolation: true,
       nodeIntegration: false,
-      sandbox: false
+      sandbox: true,
+      backgroundThrottling: true
     }
   })
   const win = chatWindow
+  // Save window size when closing (always, for chat window)
+  win.on('close', () => {
+    if (!win.isDestroyed()) {
+      const bounds = win.getBounds()
+      void updateSettings({
+        chatWindowWidth: Math.max(360, bounds.width - CHAT_SHADOW_PADDING * 2),
+        chatWindowHeight: Math.max(360, bounds.height - CHAT_SHADOW_PADDING * 2)
+      })
+    }
+  })
   win.on('closed', () => {
     if (chatWindow === win) chatWindow = null
+  })
+  // Also save on resize (debounced) for crash-safety
+  let resizeTimer: ReturnType<typeof setTimeout> | null = null
+  win.on('resized', () => {
+    if (win.isDestroyed()) return
+    if (resizeTimer) clearTimeout(resizeTimer)
+    resizeTimer = setTimeout(() => {
+      if (win.isDestroyed()) return
+      const bounds = win.getBounds()
+      void updateSettings({
+        chatWindowWidth: Math.max(360, bounds.width - CHAT_SHADOW_PADDING * 2),
+        chatWindowHeight: Math.max(360, bounds.height - CHAT_SHADOW_PADDING * 2)
+      })
+    }, 200)
   })
   win.once('ready-to-show', () => {
     win.show()
     win.focus()
   })
-  loadRenderer(win, 'chat.html')
+  loadRenderer(win, 'selectionAction.html')
 }
 
 function createTray(): void {
@@ -274,19 +357,108 @@ function applySelectionState(settings = getSettings()): void {
   refreshTrayMenu()
 }
 
+// Tool results shipped to the renderer (and replayed cross-turn by the chat
+// window) keep head + tail up to 12k — the same ceiling the model sees
+// in-turn, so replay never exceeds what was actually observed.
+const RESULT_EVENT_MAX = 12_000
+function capResultForEvent(output: string): string {
+  if (output.length <= RESULT_EVENT_MAX) return output
+  const head = output.slice(0, Math.floor(RESULT_EVENT_MAX * 0.7))
+  const tail = output.slice(-Math.floor(RESULT_EVENT_MAX * 0.25))
+  return `${head}\n[... ${output.length - head.length - tail.length} chars truncated ...]\n${tail}`
+}
+
 function registerIpc(): void {
   selectionService.registerIpc()
   screenshotService.registerIpc()
 
+  // Typing in the proxy input fires one settings update per keystroke —
+  // debounce the MCP reconnect so connections rebuild once the URL settles.
+  let mcpProxyReconnectTimer: NodeJS.Timeout | null = null
+
   ipcMain.handle(IPC.SettingsGet, () => getSettings())
   ipcMain.handle(IPC.SettingsUpdate, (_event, patch: SettingsPatch) => {
+    const prev = getSettings()
     const settings = updateSettings(patch)
-    registerShortcuts()
+    // Only re-register shortcuts if shortcut-related settings changed
+    const shortcutsChanged = JSON.stringify(prev.shortcuts) !== JSON.stringify(settings.shortcuts) ||
+      prev.actions.some((a, i) => a.shortcut !== settings.actions[i]?.shortcut) ||
+      prev.actions.length !== settings.actions.length
+    if (shortcutsChanged) registerShortcuts()
     applySelectionState(settings)
     applyAutoLaunch(settings.autoLaunch)
+    // Re-apply the proxy chain (manual > system > direct) when it changes, then
+    // rebuild MCP connections — live sockets keep using the old route otherwise.
+    if (prev.proxyUrl !== settings.proxyUrl) {
+      void applyProxy(settings.proxyUrl)
+      if (mcpProxyReconnectTimer) clearTimeout(mcpProxyReconnectTimer)
+      mcpProxyReconnectTimer = setTimeout(() => {
+        mcpProxyReconnectTimer = null
+        mcpManager.reconnectAll(getSettings().mcpServers)
+      }, 1500)
+    }
+    // Reconcile MCP connections; unchanged servers are left untouched.
+    mcpManager.sync(settings.mcpServers)
     return settings
   })
-  ipcMain.handle(IPC.OpenExternal, (_event, url: string) => shell.openExternal(url))
+  ipcMain.handle(IPC.ProxyTest, (_event, proxyUrl: string) => testProxy(typeof proxyUrl === 'string' ? proxyUrl : ''))
+
+  // Only allow protocols that make sense to hand to the OS shell. Selected
+  // text can be an arbitrary URI, so never forward schemes like javascript:.
+  ipcMain.handle(IPC.OpenExternal, (_event, url: string) => {
+    if (typeof url !== 'string') return
+    const allowed = /^(https?|mailto|file):/i.test(url) || /^[a-z]:[\\/]/i.test(url)
+    if (allowed) return shell.openExternal(url)
+  })
+  ipcMain.handle(IPC.MemoryOpen, async () => {
+    // Open the global memory file in the system editor, creating it on first use.
+    const filePath = await ensureGlobalMemoryFile(app.getPath('userData'))
+    return shell.openPath(filePath)
+  })
+  ipcMain.handle(IPC.MemoryOpenProject, (_event, workingDir: string) => {
+    if (typeof workingDir !== 'string' || !existsSync(workingDir)) return ''
+    const filePath = join(workingDir, 'AGENTS.md')
+    if (!existsSync(filePath)) writeFileSync(filePath, '# Project memory\n', 'utf8')
+    return shell.openPath(filePath)
+  })
+  ipcMain.handle(IPC.ExtStatus, async () => {
+    const settings = getSettings()
+    const skills = await scanSkills(getSkillsDir(app.getPath('userData')), settings.disabledSkills, settings.linkedSkillDirs)
+    return { skills, mcp: mcpManager.getStatuses(settings.mcpServers) }
+  })
+  ipcMain.handle(IPC.ExtOpenSkillsDir, () => {
+    const dir = getSkillsDir(app.getPath('userData'))
+    mkdirSync(dir, { recursive: true })
+    return shell.openPath(dir)
+  })
+  // Reuse an existing folder as a skill in place — validated (must contain a
+  // parseable SKILL.md), then linked by path in settings. Nothing is copied.
+  ipcMain.handle(IPC.ExtLinkSkillDir, async (event) => {
+    const win = BrowserWindow.fromWebContents(event.sender)
+    const options = { properties: ['openDirectory' as const] }
+    const result = win ? await dialog.showOpenDialog(win, options) : await dialog.showOpenDialog(options)
+    if (result.canceled || !result.filePaths[0]) return null
+    const dir = result.filePaths[0]
+    const meta = await readSkillMeta(dir)
+    if (!meta) return { ok: false as const, error: 'no-skill-md' }
+    const settings = getSettings()
+    if (!settings.linkedSkillDirs.includes(dir)) {
+      updateSettings({ linkedSkillDirs: [...settings.linkedSkillDirs, dir] })
+    }
+    return { ok: true as const, name: meta.name ?? dir }
+  })
+  ipcMain.handle(IPC.ExtUnlinkSkillDir, (_event, dir: string) => {
+    if (typeof dir !== 'string') return
+    const settings = getSettings()
+    updateSettings({
+      linkedSkillDirs: settings.linkedSkillDirs.filter((d) => d !== dir),
+      // Drop the stale disable entry too — its id is the path itself.
+      disabledSkills: settings.disabledSkills.filter((s) => s !== dir)
+    })
+  })
+  ipcMain.handle(IPC.ExtMcpReconnect, (_event, id: string) => {
+    if (typeof id === 'string') mcpManager.reconnect(getSettings().mcpServers, id)
+  })
   ipcMain.handle(IPC.SpeechSpeak, (_event, text: string) => speechService.speak(text))
   ipcMain.handle(IPC.SpeechStop, () => speechService.stop())
 
@@ -294,75 +466,317 @@ function registerIpc(): void {
     const controller = new AbortController()
     const settings = getSettings()
     abortControllers.set(request.requestId, controller)
+    injectionQueues.set(request.requestId, [])
+    // If the requesting window dies mid-stream, stop the request instead of
+    // sending chunks into a destroyed WebContents.
+    const sendChunk = (payload: Record<string, unknown>): void => {
+      if (event.sender.isDestroyed()) {
+        controller.abort()
+        return
+      }
+      event.sender.send(IPC.AiChunk, { requestId: request.requestId, ...payload })
+    }
+    event.sender.once('destroyed', () => controller.abort())
     try {
       const messages = request.messages?.length
         ? request.messages
         : [{ role: 'user' as const, text: request.prompt ?? '' }]
-      let systemPrompt = request.systemPrompt ?? buildAssistantSystemPrompt(settings)
-      const provider = resolveProvider(settings, request.providerTemplateId)
+      const systemPrompt = request.systemPrompt ?? buildAssistantSystemPrompt(settings)
+      // Clone before overriding the model — resolveProvider returns the live
+      // settings object, which is cached in settingsStore.
+      const provider = { ...resolveProvider(settings, request.providerTemplateId) }
+      if (request.model) {
+        provider.model = request.model
+      }
 
-      // Optional: web search pre-flight. Let the model decide; if yes, query Exa
-      // (via its public hosted MCP — no key required) and inject the results
-      // into the system prompt before the main stream.
-      if (settings.webSearchEnabled) {
-        const lastUser = [...messages].reverse().find((m) => m.role === 'user')
-        const userText = lastUser?.text?.trim() ?? ''
-        if (userText) {
-          try {
-            const decision = await decideSearch(
-              provider,
-              userText,
-              settings.language,
-              controller.signal,
-              { fetcher: providerFetch }
-            )
-            if (decision.needsSearch && decision.query) {
-              event.sender.send(IPC.AiChunk, {
-                requestId: request.requestId,
-                type: 'status',
-                text: decision.query
-              })
-              const results = await searchExa(decision.query, controller.signal)
-              const context = formatSearchContext(decision.query, results, settings.language)
-              if (context) systemPrompt = `${systemPrompt}\n\n${context}`
-            }
-          } catch (error) {
-            if (controller.signal.aborted) throw error
-            console.warn('[web-search] skipped:', error instanceof Error ? error.message : error)
+      // Determine whether web search tools should be included.
+      // forceSearch=true  → include tools (chat window with toggle on, or action with webSearch=true)
+      // forceSearch=false → exclude tools (action with webSearch=false)
+      // forceSearch=undefined → follow global setting (action with webSearch=inherit)
+      const enableSearch = request.forceSearch ?? settings.webSearchEnabled
+      const agentEnabled = request.agentMode === true
+      const workingDir =
+        agentEnabled && request.workingDir && existsSync(request.workingDir) ? request.workingDir : homedir()
+      // Agent mode: per-call approval is the safety net, not a sandbox. The
+      // model operates on real files; write/edit/command calls pause for the
+      // user unless they picked "always allow" for this stream.
+      let alwaysAllow = false
+
+      const useExtensions = request.useExtensions === true
+      const mcpTools = useExtensions ? mcpManager.getToolDefinitions() : []
+      const tools = [
+        ...(enableSearch ? [webSearchTool] : []),
+        ...(agentEnabled ? agentToolDefinitions : []),
+        ...mcpTools
+      ]
+      let effectiveSystemPrompt = agentEnabled
+        ? `${systemPrompt}\n\n` +
+          // Core grounding rule — placed FIRST so it anchors model behavior.
+          `IMPORTANT: You MUST use tool calls to perform actions. Describing an action in text does NOT execute it. ` +
+          `Only a tool_use/function_call returned in the API response counts as real work.\n\n` +
+          `You can operate on the user’s real file system with the tools read_file, write_file, edit_file, list_dir, search_files and run_command (${process.platform === 'win32' ? 'Git Bash syntax on Windows' : 'bash'}). Working directory: ${workingDir}. ` +
+          `Prefer search_files to locate code instead of listing and reading files one by one. Read files before editing them, prefer edit_file for small changes, and keep commands non-interactive. ` +
+          `Write/edit/command calls require user approval and may be rejected — if rejected, ask or adjust your approach instead of retrying the same call.\n\n` +
+          `Grounding rules:\n` +
+          `- Talk is not work. Nothing counts as done unless the tool call ran and returned success.\n` +
+          `- Earlier assistant messages may end with a block titled 【本轮实际执行的工具调用】. The app generates it from execution logs; it is authoritative. Trust it. NEVER write such a block yourself.\n` +
+          `- Never claim you created, edited, or verified anything without the matching tool result. Never invent outputs.\n` +
+          `- If you cannot perform an action, say so. Do not pretend it succeeded.`
+        : systemPrompt
+      if (request.useMemory === true) {
+        const userDataDir = app.getPath('userData')
+        effectiveSystemPrompt += await buildMemoryPrompt(userDataDir, agentEnabled ? workingDir : undefined)
+        // Teach the model the memory convention: explicit opt-in only, and the
+        // update path depends on whether file tools are available right now.
+        effectiveSystemPrompt += agentEnabled
+          ? `\n\nMemory convention: when the user explicitly asks you to remember something durable, append a short bullet to ${getGlobalMemoryPath(userDataDir)} (personal, cross-project preferences) or AGENTS.md in the working directory (project conventions) using edit_file/write_file. Never store anything the user did not ask to remember; remove entries when asked to forget.`
+          : `\n\nMemory convention: if the user asks you to remember something durable, you cannot edit files in this mode — ask them to enable agent mode (the terminal button) so you can update the memory file.`
+      }
+      if (useExtensions && agentEnabled) {
+        // Progressive skill loading: only the metadata list is injected; the
+        // agent reads a SKILL.md with read_file when a task matches.
+        const skills = await scanSkills(getSkillsDir(app.getPath('userData')), settings.disabledSkills, settings.linkedSkillDirs)
+        effectiveSystemPrompt += buildSkillsPrompt(skills)
+      }
+
+      const runAgentTool = async (name: string, args: Record<string, unknown>): Promise<string> => {
+        const callId = randomUUID()
+        const summary = summarizeToolCall(name, args, workingDir)
+        // For write/edit ship the proposed content so the renderer can show a diff.
+        const diff: Partial<AgentToolEvent> =
+          name === 'edit_file'
+            ? { oldText: String(args.old_text ?? '').slice(0, 4000), newText: String(args.new_text ?? '').slice(0, 4000) }
+            : name === 'write_file'
+              ? { newText: String(args.content ?? '').slice(0, 4000) }
+              : {}
+        const sendTool = (patch: Partial<AgentToolEvent>): void => {
+          sendChunk({ type: 'tool', tool: { callId, toolName: name, summary, ...diff, ...patch } })
+        }
+        // Risk gate: forbidden commands never run; dangerous ones always
+        // pause for approval, even in full-access / always-allow mode.
+        const risk = name === 'run_command' ? assessCommandRisk(String(args.command ?? '')) : 'safe'
+        if (risk === 'forbidden') {
+          sendTool({ state: 'error', result: 'Blocked: destructive command' })
+          return '[Blocked: this command is classified as destructive and will never be executed. Do not retry it.]'
+        }
+        const approvalWaived = alwaysAllow || getSettings().agentFullAccess === true
+        if (risk === 'dangerous' || (!approvalWaived && requiresApproval(name, args, workingDir))) {
+          sendTool({ state: 'pending-approval' })
+          const approval = await waitForApproval(callId, request.requestId, controller.signal)
+          if (approval.alwaysAllow) alwaysAllow = true
+          if (!approval.approved) {
+            sendTool({ state: 'rejected' })
+            return '[User rejected this action. Ask for clarification or try a different approach.]'
           }
+        }
+        sendTool({ state: 'running' })
+        const snapshot = await snapshotForMutation(name, args, workingDir)
+        // Live output for long-running commands: keep the tail, throttle pushes.
+        let liveBuffer = ''
+        let liveTimer: NodeJS.Timeout | null = null
+        const pushLiveOutput = (chunk: string): void => {
+          liveBuffer = (liveBuffer + chunk).slice(-2000)
+          if (liveTimer) return
+          liveTimer = setTimeout(() => {
+            liveTimer = null
+            sendTool({ state: 'running', liveOutput: liveBuffer })
+          }, 300)
+        }
+        try {
+          const output = await executeAgentTool(
+            name,
+            args,
+            workingDir,
+            controller.signal,
+            name === 'run_command' ? pushLiveOutput : undefined
+          )
+          if (snapshot) void saveSnapshot(callId, snapshot)
+          // Mirror the in-turn 12k cap (head + tail) so cross-turn replay via
+          // toolRecap can carry the same content the model saw this turn.
+          sendTool({ state: 'done', result: capResultForEvent(output) })
+          return output
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error)
+          sendTool({ state: 'error', result: message })
+          return `[Tool failed: ${message}]`
+        } finally {
+          if (liveTimer) clearTimeout(liveTimer)
+        }
+      }
+
+      // External MCP tools always pause for approval unless "always allow" —
+      // we cannot know what a third-party server will do.
+      const runMcpTool = async (name: string, args: Record<string, unknown>): Promise<string> => {
+        const callId = randomUUID()
+        const summary = `${mcpManager.describeTool(name)} · ${JSON.stringify(args).slice(0, 160)}`
+        const sendTool = (patch: Partial<AgentToolEvent>): void => {
+          sendChunk({ type: 'tool', tool: { callId, toolName: name, summary, ...patch } })
+        }
+        if (!alwaysAllow) {
+          sendTool({ state: 'pending-approval' })
+          const approval = await waitForApproval(callId, request.requestId, controller.signal)
+          if (approval.alwaysAllow) alwaysAllow = true
+          if (!approval.approved) {
+            sendTool({ state: 'rejected' })
+            return '[User rejected this action. Ask for clarification or try a different approach.]'
+          }
+        }
+        sendTool({ state: 'running' })
+        try {
+          const output = await mcpManager.callTool(name, args, controller.signal)
+          sendTool({ state: 'done', result: capResultForEvent(output) })
+          return output.slice(0, 20_000)
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error)
+          sendTool({ state: 'error', result: message })
+          return `[Tool failed: ${message}]`
         }
       }
 
       await streamChatMessages(
         provider,
         messages,
-        systemPrompt,
+        effectiveSystemPrompt,
         controller.signal,
         (delta) => {
-          event.sender.send(IPC.AiChunk, { requestId: request.requestId, type: 'delta', text: delta })
+          if (delta.content) {
+            sendChunk({ type: 'delta', text: delta.content })
+          }
+          if (delta.reasoning) {
+            sendChunk({ type: 'reasoning', reasoning: delta.reasoning })
+          }
         },
         request.reasoning ?? 'on',
-        { fetcher: providerFetch }
+        {
+          fetcher: providerFetch,
+          tools: tools.length ? tools : undefined,
+          // Agent mode: lower temperature to reduce hallucinated tool calls.
+          agentTemperature: agentEnabled ? 0.2 : undefined,
+          // Agent/MCP runs span many rounds and can pause on user approval.
+          // Models often issue one call per round, so real tasks (read × N +
+          // edit × N + build/test) need generous headroom.
+          maxToolRounds: agentEnabled || mcpTools.length ? 50 : 5,
+          toolLoopTimeoutMs: agentEnabled || mcpTools.length ? 900_000 : 60_000,
+          // When the round budget is exhausted mid-task, tell the user instead
+          // of ending silently (looks like an unexplained interruption).
+          roundLimitNotice:
+            agentEnabled || mcpTools.length
+              ? settings.language === 'zh-CN'
+                ? '⚠️ 已达到单次对话的最大工具调用轮次（任务尚未完成）。可回复“继续”让我接着做。'
+                : '⚠️ Reached the max tool-call rounds for one turn (task may be unfinished). Reply “continue” to keep going.'
+              : undefined,
+          // Between tool rounds, hand queued user notes to the loop and tell
+          // the renderer they were actually delivered (vs. left for fallback).
+          drainInjected: () => {
+            const queue = injectionQueues.get(request.requestId)
+            if (!queue?.length) return []
+            const notes = queue.splice(0)
+            for (const note of notes) sendChunk({ type: 'injected', text: note })
+            return notes.map((note) =>
+              settings.language === 'zh-CN'
+                ? `[用户在任务执行中途发来的指引，请据此调整后续步骤]\n${note}`
+                : `[Mid-task guidance from the user — adjust your next steps accordingly]\n${note}`
+            )
+          },
+          onStatus: (text: string, toolName?: string) => {
+            // Agent tools render their own cards; the status line is search-only.
+            if (toolName && toolName !== webSearchTool.name) return
+            sendChunk({ type: 'status', text })
+          },
+          onToolCall: async (name: string, args: Record<string, unknown>) => {
+            if (name === webSearchTool.name) {
+              const query = typeof args.query === 'string' ? args.query : ''
+              if (!query) return 'No search query provided.'
+              const results = await searchWithFallback(query, controller.signal, 10, providerFetch)
+              return formatSearchContext(query, results, settings.language)
+            }
+            if (isMcpToolName(name) && mcpManager.ownsTool(name)) {
+              return runMcpTool(name, args)
+            }
+            return runAgentTool(name, args)
+          }
+        }
       )
-      event.sender.send(IPC.AiChunk, { requestId: request.requestId, type: 'done' })
+      sendChunk({ type: 'done' })
     } catch (error) {
       if (controller.signal.aborted) {
-        event.sender.send(IPC.AiChunk, { requestId: request.requestId, type: 'done' })
+        sendChunk({ type: 'done' })
       } else {
-        event.sender.send(IPC.AiChunk, {
-          requestId: request.requestId,
+        sendChunk({
           type: 'error',
           error: error instanceof Error ? error.message : String(error)
         })
       }
     } finally {
+      cancelApprovalsForRequest(request.requestId)
       abortControllers.delete(request.requestId)
+      injectionQueues.delete(request.requestId)
     }
   })
 
   ipcMain.handle(IPC.AiAbort, (_event, requestId: string) => {
     abortControllers.get(requestId)?.abort()
     abortControllers.delete(requestId)
+    injectionQueues.delete(requestId)
+  })
+
+  // Queue a user note for a running request. Returns false when the request
+  // already finished — the renderer then sends the note as a normal message.
+  ipcMain.handle(IPC.AiInject, (_event, requestId: string, text: string) => {
+    if (typeof requestId !== 'string' || typeof text !== 'string' || !text.trim()) return false
+    const queue = injectionQueues.get(requestId)
+    if (!queue) return false
+    queue.push(text)
+    return true
+  })
+
+  ipcMain.handle(IPC.AgentPickWorkingDir, async (event) => {
+    const win = BrowserWindow.fromWebContents(event.sender)
+    const options = { properties: ['openDirectory' as const] }
+    const result = win ? await dialog.showOpenDialog(win, options) : await dialog.showOpenDialog(options)
+    return result.canceled ? null : (result.filePaths[0] ?? null)
+  })
+  ipcMain.handle(IPC.AgentApproveTool, (_event, callId: string, approved: boolean, alwaysAllow?: boolean) => {
+    if (typeof callId !== 'string') return false
+    return resolveApproval(callId, approved === true, alwaysAllow === true)
+  })
+  ipcMain.handle(IPC.AgentRevertTool, async (_event, callId: string) => {
+    if (typeof callId !== 'string') return false
+    const snapshot = await loadSnapshot(callId)
+    if (!snapshot) return false
+    try {
+      await restoreSnapshot(snapshot)
+      await deleteSnapshot(callId)
+      return true
+    } catch {
+      return false
+    }
+  })
+  // Export a chat transcript as Markdown. The renderer builds the markdown;
+  // main writes straight into Downloads and reveals the file in Explorer.
+  // No native save dialog: its modal message loop deadlocks with the global
+  // selection hook on Windows (observed as "not responding" + forced exit).
+  ipcMain.handle(IPC.ChatExportMarkdown, async (_event, payload: { title?: string; markdown?: string }) => {
+    if (typeof payload?.markdown !== 'string' || !payload.markdown.trim()) return null
+    const safeTitle =
+      (typeof payload.title === 'string' ? payload.title : '')
+        .replace(/[\\/:*?"<>|\n\r]/g, ' ')
+        .trim()
+        .slice(0, 60) || 'chat'
+    const stamp = new Date().toISOString().slice(0, 10)
+    try {
+      const dir = app.getPath('downloads')
+      // Avoid clobbering an earlier export with the same title.
+      let filePath = join(dir, `${safeTitle} ${stamp}.md`)
+      for (let i = 2; existsSync(filePath) && i < 100; i++) {
+        filePath = join(dir, `${safeTitle} ${stamp} (${i}).md`)
+      }
+      await writeFile(filePath, payload.markdown, 'utf8')
+      shell.showItemInFolder(filePath)
+      return filePath
+    } catch {
+      return null
+    }
   })
   ipcMain.handle(IPC.AiListModels, (_event, providerTemplateId?: string) =>
     listModels(resolveProvider(getSettings(), providerTemplateId), { fetcher: providerFetch })
@@ -371,15 +785,95 @@ function registerIpc(): void {
     await testModel(resolveProvider(getSettings(), providerTemplateId), { fetcher: providerFetch })
     return { ok: true }
   })
+
+  // Compress old chat history into a structured summary.
+  // Order: compressModel (if set) → retry once → fall back to the chat model
+  // passed by the renderer. Failures throw so the UI can keep compactRef and
+  // retry on the next completed turn (truncateForSend still caps payload size).
+  ipcMain.handle(IPC.AiSummarize, async (_event, payload: { text: string; model?: string }) => {
+    if (typeof payload?.text !== 'string' || !payload.text.trim()) return ''
+    const settings = getSettings()
+    const base = resolveProvider(settings, undefined)
+    const chatModel =
+      (typeof payload.model === 'string' && payload.model.trim()) || base.model
+    const compressModel = settings.compressModel.trim()
+    // Prefer dedicated compress model, then the live chat model.
+    const candidates = [...new Set([compressModel, chatModel].filter(Boolean))]
+    if (!candidates.length) candidates.push(base.model)
+
+    const systemPrompt = [
+      '你是对话历史压缩器。把给定的对话（可能包含一段已有摘要）合并压缩成一份结构化摘要，供后续对话作为上下文。',
+      '输出格式（缺的小节可省略）：',
+      '## 对话目标',
+      '## 关键信息与事实',
+      '## 已完成 / 已决定',
+      '## 待办与未决问题',
+      '要求：只保留对后续对话有用的内容；专有名词、数据、代码要点保留原文；用原对话的主要语言书写；总长不超过 800 字；直接输出摘要，不要寒暄。'
+    ].join('\n')
+
+    const runOnce = async (model: string): Promise<string> => {
+      const provider = { ...base, model }
+      let summary = ''
+      const controller = new AbortController()
+      const timeout = setTimeout(() => controller.abort(), 60_000)
+      try {
+        await streamChatMessages(
+          provider,
+          [{ role: 'user', text: payload.text }],
+          systemPrompt,
+          controller.signal,
+          (delta) => {
+            if (delta.content) summary += delta.content
+          },
+          'off',
+          { fetcher: providerFetch }
+        )
+      } finally {
+        clearTimeout(timeout)
+      }
+      return summary.trim()
+    }
+
+    let lastError: unknown
+    for (const model of candidates) {
+      // Two attempts per model (network blips / empty first response).
+      for (let attempt = 0; attempt < 2; attempt++) {
+        try {
+          const summary = await runOnce(model)
+          if (summary) return summary
+          lastError = new Error(`Empty summary from model ${model}`)
+        } catch (error) {
+          lastError = error
+        }
+      }
+    }
+    const message =
+      lastError instanceof Error ? lastError.message : String(lastError ?? 'summarize failed')
+    throw new Error(message)
+  })
 }
 
 if (!app.requestSingleInstanceLock()) {
   app.quit()
 } else {
   void app.whenReady().then(() => {
-    electronApp.setAppUserModelId('com.selectionassistant.lite')
+    app.setAppUserModelId('com.selectionassistant.lite')
     app.dock?.setIcon(appIcon)
-    app.on('browser-window-created', (_event, window) => optimizer.watchWindowShortcuts(window))
+    // Apply the proxy chain first so MCP connections go through it too.
+    void applyProxy(getSettings().proxyUrl).finally(() => {
+      // Bring up enabled MCP server connections in the background.
+      mcpManager.sync(getSettings().mcpServers)
+    })
+    app.on('browser-window-created', (_event, window) => {
+  // optimizer.watchWindowShortcuts equivalent: F12 toggle devtools in dev
+  if (!app.isPackaged) {
+    window.webContents.on('before-input-event', (_e, input) => {
+      if (input.key === 'F12') {
+        window.webContents.toggleDevTools()
+      }
+    })
+  }
+})
 
     registerIpc()
     createTray()
@@ -394,6 +888,22 @@ if (!app.requestSingleInstanceLock()) {
       refreshTrayMenu()
     })
 
+    // Prevent in-app navigation: all external links open in the default browser.
+    app.on('web-contents-created', (_event, contents) => {
+      contents.setWindowOpenHandler(({ url }) => {
+        if (url.startsWith('http://') || url.startsWith('https://')) {
+          void shell.openExternal(url)
+        }
+        return { action: 'deny' }
+      })
+      contents.on('will-navigate', (event, url) => {
+        if (url.startsWith('http://') || url.startsWith('https://')) {
+          event.preventDefault()
+          void shell.openExternal(url)
+        }
+      })
+    })
+
     // A login-triggered launch (or any '--hidden' start) stays in the tray.
     if (!wasStartedHidden()) createSettingsWindow()
   })
@@ -406,5 +916,6 @@ if (!app.requestSingleInstanceLock()) {
     selectionService.dispose()
     screenshotService.dispose()
     speechService.dispose()
+    mcpManager.closeAll()
   })
 }

--- a/src/shared/actions.ts
+++ b/src/shared/actions.ts
@@ -107,6 +107,8 @@ export function mergeSettings(current: AppSettings, patch: SettingsPatch): AppSe
       typeof rest.webSearchEnabled === 'boolean' ? rest.webSearchEnabled : current.webSearchEnabled,
     actionWindowWidth: clampInt(rest.actionWindowWidth ?? current.actionWindowWidth, 320, 1600, defaultSettings.actionWindowWidth),
     actionWindowHeight: clampInt(rest.actionWindowHeight ?? current.actionWindowHeight, 240, 1200, defaultSettings.actionWindowHeight),
+    chatWindowWidth: rest.chatWindowWidth != null ? clampInt(rest.chatWindowWidth, 360, 2000, 440) : current.chatWindowWidth,
+    chatWindowHeight: rest.chatWindowHeight != null ? clampInt(rest.chatWindowHeight, 360, 2000, 580) : current.chatWindowHeight,
     fontFamily: typeof (rest.fontFamily ?? current.fontFamily) === 'string' ? (rest.fontFamily ?? current.fontFamily) : '',
     fontSize: clampInt(rest.fontSize ?? current.fontSize, 10, 28, defaultSettings.fontSize),
     autoLaunch: typeof (rest.autoLaunch ?? current.autoLaunch) === 'boolean' ? (rest.autoLaunch ?? current.autoLaunch) : false,
@@ -144,7 +146,7 @@ function normalizeProviderSettings(provider: Partial<ProviderSettings> | Provide
     ...defaultProviderTemplate.provider,
     ...provider,
     apiType: normalizeProviderApiType(provider.apiType),
-    temperature: 1
+    temperature: provider.temperature ?? 1
   }
 }
 
@@ -218,7 +220,9 @@ function normalizeActionItems(actions: unknown): ActionItem[] {
       promptTemplate: normalizeOptionalString(candidate.promptTemplate),
       searchUrlTemplate: normalizeOptionalString(candidate.searchUrlTemplate),
       providerTemplateId: normalizeOptionalString(candidate.providerTemplateId),
+      model: normalizeOptionalString(candidate.model),
       reasoning: normalizeReasoning(candidate.reasoning),
+      webSearch: typeof candidate.webSearch === 'boolean' ? candidate.webSearch : undefined,
       shortcut: normalizeOptionalString(candidate.shortcut)
     })
   }


### PR DESCRIPTION
## Problem

Agent 模式下模型会概率性地跳过工具调用，用文本描述"已完成操作"来代替实际的 tool_use，造成幻觉。

## Root Causes & Fixes

### 1. System Prompt 精简 + 核心规则前置
- **原因**：grounding rules 淹没在冗长的 system prompt 中，"don't do X" 式的否定指令过多反而降低遵从度
- **改动**：将核心规则 `IMPORTANT: You MUST use tool calls to perform actions` 提到最前面；将 5 条冗长规则精简为 4 条简洁规则

### 2. Agent 模式降温 (1.0 → 0.2)
- **原因**：`temperature: 1` 放大了模型"创造性地"跳过工具调用的概率
- **改动**：新增 `agentTemperature` 选项，agent 模式下自动使用 0.2

### 3. 幻觉检测 + 自动警告
- **原因**：当模型在多轮对话中途停止调用工具但生成了"已创建/已修改/已执行"等文本时，用户无从分辨真假
- **改动**：在 `toolCalls.length === 0` 时检测 roundText 中的幻觉模式，自动追加 ⚠️ 警告

### 4. Temperature 不再硬编码
- **原因**：`normalizeProviderSettings` 硬编码 `temperature: 1`，忽略用户配置
- **改动**：改为 `provider.temperature ?? 1`

## Files Changed
- `src/main/ai/OpenAICompatibleClient.ts` — agentTemperature 支持 + 幻觉检测
- `src/main/index.ts` — system prompt 精简 + agentTemperature: 0.2
- `src/shared/actions.ts` — temperature 不再硬编码